### PR TITLE
Add support for additional frameworks

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
     "base_url": "http://downloads.mesosphere.io/playa-mesos",
     "ip_address": "10.141.141.10",
     "vm_ram": "2048",
-    "vm_cpus": "2"
+    "vm_cpus": "2",
+    "mesos_frameworks": "'marathon'"
 }

--- a/doc/config.md
+++ b/doc/config.md
@@ -21,3 +21,6 @@ MB of RAM allocated to the VM
 
 ###### _*vm_cpus*_
 Number of CPU cores allocated to the VM
+
+###### _*mesos_frameworks*_
+Mesos frameworks to be installed

--- a/lib/scripts/common/mesosflexinstall
+++ b/lib/scripts/common/mesosflexinstall
@@ -4,6 +4,7 @@ function -h {
 cat <<USAGE
  USAGE: mesosflexinstall (--rel <mesos-version>)?
                          (--slave-hostname <SLAVE_HOSTNAME>)?
+                         (--frameworks <frameworks>)?
 
   Install and configure Mesos with Zookeeper support.
 
@@ -34,6 +35,7 @@ function options {
     case "$1" in
       --rel)            rel="$2"                 ; shift ;;
       --slave-hostname) slave_hostname="$2"      ; shift ;; # See: MESOS-825
+      --frameworks) frameworks="$2"  ; shift ;; # See: MESOS-825
       --*)              err "No such option: $1" ;;
     esac
     shift
@@ -66,9 +68,16 @@ function install_apt_source {
 function install_with_apt {
   apt_ curl unzip
   install_apt_source $1
-  apt_ zookeeperd zookeeper zookeeper-bin docker.io mesos marathon deimos
+  apt_ zookeeperd zookeeper zookeeper-bin docker.io mesos deimos
+  install_frameworks
   as_root ln -sf /usr/bin/docker.io /usr/local/bin/docker
   as_root sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/docker.io
+}
+
+function install_frameworks {
+  if [[ ${frameworks+isset} ]]; then
+    apt_ ${frameworks}
+  fi
 }
 
 function apt_ {

--- a/packer/packer-virtualbox.json
+++ b/packer/packer-virtualbox.json
@@ -80,7 +80,7 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}}",
+      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}} --frameworks {{user `mesos_frameworks`}}",
       "scripts": [
         "{{user `scripts`}}/common/mesosflexinstall"
       ],
@@ -103,7 +103,8 @@
     "ip_address": null,
     "vm_ram": null,
     "vm_cpus": null,
-    "scripts": "../lib/scripts"
+    "scripts": "../lib/scripts",
+    "mesos_frameworks": null
   }
 }
 

--- a/packer/packer-vmware_fusion.json
+++ b/packer/packer-vmware_fusion.json
@@ -70,7 +70,7 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}}",
+      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}} --frameworks {{user `mesos_frameworks`}}",
       "scripts": [
         "{{user `scripts`}}/common/mesosflexinstall"
       ],
@@ -93,7 +93,8 @@
     "ip_address": null,
     "vm_ram": null,
     "vm_cpus": null,
-    "scripts": "../lib/scripts"
+    "scripts": "../lib/scripts",
+    "mesos_frameworks": null
   }
 }
 

--- a/packer/packer-vmware_workstation.json
+++ b/packer/packer-vmware_workstation.json
@@ -70,7 +70,7 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}}",
+      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}' --slave-hostname {{user `ip_address`}} --frameworks {{user `mesos_frameworks`}}",
       "scripts": [
         "{{user `scripts`}}/common/mesosflexinstall"
       ],
@@ -93,7 +93,8 @@
     "ip_address": null,
     "vm_ram": null,
     "vm_cpus": null,
-    "scripts": "../lib/scripts"
+    "scripts": "../lib/scripts",
+    "mesos_frameworks": null
   }
 }
 


### PR DESCRIPTION
marathon is left there as default (this changes nothing in the current behaviour).
If the mesos_frameworks var is changed to "'marathon chronos'", both marathon and chronos would get installed

This can be the first stab at getting frameworks installed.
