### PR TITLE
url has changed for mirror

### DIFF
--- a/packer/packer-virtualbox.json
+++ b/packer/packer-virtualbox.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer/packer-virtualbox.json
+++ b/packer/packer-virtualbox.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04.2-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer/packer-vmware_fusion.json
+++ b/packer/packer-vmware_fusion.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer/packer-vmware_fusion.json
+++ b/packer/packer-vmware_fusion.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04.2-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer/packer-vmware_workstation.json
+++ b/packer/packer-vmware_workstation.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer/packer-vmware_workstation.json
+++ b/packer/packer-vmware_workstation.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/trusty/ubuntu-14.04.2-server-amd64.iso",
       "output_directory": "builds/tmp/{{user `box_name`}}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",


### PR DESCRIPTION
http://releases.ubuntu.com/trusty/ubuntu-14.04.2-server-amd64.iso is the new url for the iso mirror. i apologize i am new on github, didn't catch the url was the same in all three files. 