### PR TITLE
Add option to specify Mesos version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :shell do |shell|
       shell.path = 'lib/scripts/common/mesosflexinstall'
       arg_array = ['--slave-hostname', pmconf.ip_address]
+
+      # If mesos_release exists in the config.json file, pass the '--rel'
+      # argument and a version to mesosflexinstall. Otherwise, do nothing.
+      if pmconf.instance_variable_get(:@settings).include?('mesos_release')
+        arg_array += ['--rel', pmconf.mesos_release]
+      end
+
       # Using an array for shell args requires Vagrant 1.4.0+
       # TODO: Set as array directly when Vagrant 1.3 support is dropped
       shell.args = arg_array.join(' ')

--- a/doc/config.md
+++ b/doc/config.md
@@ -16,6 +16,11 @@ Download path is dynamically extracted with this schema: `base_url`/`platform`/`
 ###### _*ip_address*_
 IP address used by the VM on a private network using a /24 netmask
 
+###### _*mesos_release*_
+Optional configuration parameter to install a specific version of Mesos. This
+should be the full string as returned by `apt-cache policy mesos`. For example:
+`0.22.1-1.0.ubuntu1404`.
+
 ###### _*vm_ram*_
 MB of RAM allocated to the VM
 

--- a/lib/scripts/common/mesosflexinstall
+++ b/lib/scripts/common/mesosflexinstall
@@ -66,10 +66,12 @@ function install_apt_source {
 }
 
 function install_with_apt {
+  [[ ! -z ${rel-''} ]] && mesos_rel="mesos=${rel}" || mesos_rel="mesos"
+
   apt_ curl unzip
   install_apt_source $1
   install_docker
-  apt_ zookeeperd zookeeper zookeeper-bin mesos marathon chronos
+  apt_ zookeeperd zookeeper zookeeper-bin $mesos_rel marathon chronos
   as_root sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/docker
   restart_services
 }


### PR DESCRIPTION
The mesosflexinstall script has support for a `--rel` argument to
specify a Mesos release to be installed. Prior to this commit, if
this argument was passed to the script it would be set, but
wouldn't actually be used when installing Mesos.

This commit introduces a `mesos_release` option in config.json. If
the user creates this configuration option (key), mesosflexinstall
is called with `--rel` and the version string. If the configuration
option doesn't exist in config.json, mesosflexinstall will maintain
its current behavior (install latest).